### PR TITLE
refactor espresso and change decompiled class file to be in extracted

### DIFF
--- a/espresso/espresso.py
+++ b/espresso/espresso.py
@@ -177,8 +177,7 @@ class Espresso(ServiceBase):
         supplementary file.
 
         :param certs: the keytool -printcert string representation of a certificate/certificate chain
-        :param cur_file: the file path of the certificate (to be used in supplementary_files)
-        :param output_files: the files of interest out of this function (to be stored in supplementary or extracted)
+        :param cur_file: the file path of the certificate
         :return:
         """
         certs = certificate_chain_from_printcert(certs)
@@ -240,7 +239,6 @@ class Espresso(ServiceBase):
         For now it analyzes the manifest file and the certificate(s)
 
         :param meta_dir: the path of the META-INF folder
-        :param supplementary_files: the service's supplementary files
         :return:
         """
         # iterate over all files in META-INF folder
@@ -502,7 +500,7 @@ class Espresso(ServiceBase):
         if root_analysis_result.subsections:
             result_list.append(root_analysis_result)
 
-        # First stored important files with PE or launchable file in extracted file
+        # attach result section to relevant files. Get interesting files to add to extracted
         important_output_files = self.recurse_add_result(request.result, important_result_list)
 
         for desc, file in important_output_files:

--- a/espresso/espresso.py
+++ b/espresso/espresso.py
@@ -2,6 +2,7 @@ import hashlib
 import logging
 import os
 import zipfile
+import concurrent.futures
 from concurrent.futures import ThreadPoolExecutor
 from subprocess import PIPE, Popen
 
@@ -12,6 +13,7 @@ from assemblyline_service_utilities.common.keytool_parse import certificate_chai
 from assemblyline_v4_service.common.base import ServiceBase
 from assemblyline_v4_service.common.result import BODY_FORMAT, Heuristic, Result, ResultSection
 from assemblyline_v4_service.common.utils import set_death_signal
+from .file_result import FileResult, ClassAttributes
 from javatools.manifest import Manifest
 
 G_LAUNCHABLE_EXTENSIONS = [
@@ -24,8 +26,6 @@ G_LAUNCHABLE_EXTENSIONS = [
     "SCR",  # Windows screensaver
 ]
 
-APPLET = "applet"
-APPLET_MZ = "mz_in_applet"
 
 Classification = forge.get_classification()
 
@@ -39,16 +39,6 @@ class Espresso(ServiceBase):
     def __init__(self, config=None):
         super(Espresso, self).__init__(config)
         self.cfr = "/opt/al/support/espresso/cfr.jar"
-        self.applet_found = 0
-        self.classloader_found = 0
-        self.security_found = 0
-        self.url_found = 0
-        self.runtime_found = 0
-        self.manifest_tags = None
-        self.signature_block_certs = None
-        self.num_unique_headers = {}
-        self.embedded_pes = []
-        self.launchable_files = []
 
     @staticmethod
     def get_tool_version(**_):
@@ -115,11 +105,10 @@ class Espresso(ServiceBase):
         except (IOError, zipfile.BadZipfile):
             self.log.info(f"Not a ZIP File or Corrupt ZIP File: {filename}")
             return False
+        except NotJARException:
+            self.log.info(f"Not a JAR File: {filename}")
+            raise NotJARException
         except Exception as e:
-            if type(e) == NotJARException:
-                self.log.info(f"Not a JAR File: {filename}")
-                raise
-
             self.log.exception(f"Caught an exception while analysing the file {filename}. [{e}]")
             return False
         finally:
@@ -146,7 +135,7 @@ class Espresso(ServiceBase):
             else:
                 return None
 
-    def decompile_class(self, path_to_file, new_files, decompiled_dir, extract_dir):
+    def decompile_class_file(self, path_to_file, decompiled_dir, extract_dir):
         # Decompile file
         decompiled = self.decompile_to_str(path_to_file)
 
@@ -158,12 +147,11 @@ class Espresso(ServiceBase):
                 java_handle.write(decompiled)
                 java_handle.close()
 
-            txt = f"Decompiled {path_to_file.replace(extract_dir + '/', '').replace(decompiled_dir + '/', '')}"
+            desc = f"Decompiled {path_to_file.replace(extract_dir + '/', '').replace(decompiled_dir + '/', '')}"
             name = decompiled_path.replace(extract_dir + "/", "").replace(decompiled_dir + "/", "")
-            new_files.append((decompiled_path, name, txt))
-            return len(decompiled), hashlib.sha1(decompiled).hexdigest(), os.path.basename(decompiled_path)
+            return decompiled_path, name, desc
         else:
-            return 0, "", ""
+            return None, None, None
 
     @staticmethod
     def find_decompiled_file(class_file):
@@ -173,63 +161,16 @@ class Espresso(ServiceBase):
         return None
 
     def do_class_analysis(self, data):
-        has_interesting_attributes = False
-        if b"java/applet/Applet" in data:
-            self.applet_found += 1
-            has_interesting_attributes = True
+        interesting_attributes = ClassAttributes.empty_class_attributes()
+        interesting_attributes.applet_found = b"java/applet/Applet" in data
+        interesting_attributes.classloader_found = b"ClassLoader" in data
+        interesting_attributes.security_found = b"/security/" in data
+        interesting_attributes.url_found = b"net/URL" in data
+        interesting_attributes.runtime_found = b"java/lang/Runtime" in data
 
-        if b"ClassLoader" in data:
-            self.classloader_found += 1
-            has_interesting_attributes = True
+        return interesting_attributes
 
-        if b"/security/" in data:
-            self.security_found += 1
-            has_interesting_attributes = True
-
-        if b"net/URL" in data:
-            self.url_found += 1
-            has_interesting_attributes = True
-
-        if b"java/lang/Runtime" in data:
-            self.runtime_found += 1
-            has_interesting_attributes = True
-
-        return has_interesting_attributes
-
-    # noinspection PyUnusedLocal
-    def analyse_class_file(
-        self,
-        file_res,
-        cf,
-        cur_file,
-        cur_file_path,
-        start_bytes,
-        imp_res_list,
-        supplementary_files,
-        decompiled_dir,
-        extract_dir
-    ):
-        if start_bytes[:4] == b"\xCA\xFE\xBA\xBE":
-            cur_file.seek(0)
-            cur_file_full_data = cur_file.read()
-
-            # Analyse file for suspicious functions
-            if self.do_class_analysis(cur_file_full_data):
-                self.decompile_class(cur_file_path, supplementary_files, decompiled_dir, extract_dir)
-
-        else:
-            # Could not deobfuscate
-            cur_file.seek(0)
-            first_256 = cur_file.read(256)
-            hex_first_256 = hexdump(first_256)
-
-            if hex_first_256 in self.num_unique_headers:
-                self.num_unique_headers[hex_first_256].append(cur_file_path)
-            else:
-                self.num_unique_headers[hex_first_256] = [cur_file_path]
-
-
-    def validate_certs(self, certs, cur_file, supplementary_files):
+    def validate_certs(self, certs, cur_file):
         """
         This method tags out of a certificate or certificate chain. The start and
         end date, issuer, and owner are all pulled. The certificate itself is included as a
@@ -237,10 +178,12 @@ class Espresso(ServiceBase):
 
         :param certs: the keytool -printcert string representation of a certificate/certificate chain
         :param cur_file: the file path of the certificate (to be used in supplementary_files)
-        :param supplementary_files: the services supplementary files
+        :param output_files: the files of interest out of this function (to be stored in supplementary or extracted)
         :return:
         """
         certs = certificate_chain_from_printcert(certs)
+        signature_block_certs = []
+        output_files = []
 
         for cert in certs:
             res_cert = ResultSection(
@@ -282,14 +225,16 @@ class Espresso(ServiceBase):
                 if len(cert.country) != 2 or is_int_country:
                     ResultSection("Invalid country code in certificate owner", parent=res_cert, heuristic=Heuristic(14))
 
-            self.signature_block_certs.append(res_cert)
+            signature_block_certs.append(res_cert)
 
             if len(res_cert.subsections) > 0:
                 name = os.path.basename(cur_file)
                 desc = f"JAR Signature Block: {name}"
-                supplementary_files.append((cur_file.decode("utf-8"), name.decode("utf-8"), desc))
+                output_files.append((cur_file.decode("utf-8"), name.decode("utf-8"), desc))
 
-    def analyse_meta_information(self, meta_dir, supplementary_files):
+        return signature_block_certs, output_files
+
+    def analyse_meta_information(self, meta_dir):
         """
         this function pulls the meta information out of the META-INF folder.
         For now it analyzes the manifest file and the certificate(s)
@@ -300,6 +245,9 @@ class Espresso(ServiceBase):
         """
         # iterate over all files in META-INF folder
         mf = Manifest()
+        manifest_tags = []
+        certs = []
+        output_files = []
         for filename in os.listdir(meta_dir):
             cur_file = os.path.join(meta_dir, filename)
             if cur_file.upper().endswith(b"MANIFEST.MF"):  # handle jar manifest
@@ -311,10 +259,10 @@ class Espresso(ServiceBase):
                 if mf.get("Main-Class"):
                     main = tuple(mf["Main-Class"].rsplit(".", 1))
                     if len(main) == 2:
-                        self.manifest_tags.append(("file.jar.main_class", main[1]))
-                        self.manifest_tags.append(("file.jar.main_package", main[0]))
+                        manifest_tags.append(("file.jar.main_class", main[1]))
+                        manifest_tags.append(("file.jar.main_package", main[0]))
                     elif len(main) == 1:
-                        self.manifest_tags.append(("file.jar.main_class", main[0]))
+                        manifest_tags.append(("file.jar.main_class", main[0]))
 
                 # Extract information about the packages imported
                 for package_str in mf.get("Import-Package", "").split(","):
@@ -324,12 +272,15 @@ class Espresso(ServiceBase):
                         # There's a version associated to package, overwrite value before tagging
                         data = package_str.replace(";version", "=").replace('"', "")
 
-                    self.manifest_tags.append(("file.jar.imported_package", data))
+                    manifest_tags.append(("file.jar.imported_package", data))
 
             else:
                 stdout = keytool_printcert(cur_file)
+
                 if stdout:  # if stdout isn't None then the file must have been a certificate
-                    self.validate_certs(stdout, cur_file, supplementary_files)
+                    certs, output_files = self.validate_certs(stdout, cur_file)
+
+        return manifest_tags, certs, output_files
 
     def decompile_jar(self, path_to_file, target_dir):
         cfr = Popen(
@@ -347,257 +298,272 @@ class Espresso(ServiceBase):
         filename = os.path.basename(temp_filename)
         extract_dir = os.path.join(self.working_directory, f"{filename}_extracted")
         decompiled_dir = os.path.join(self.working_directory, f"{filename}_decompiled")
-        file_res = request.result
-        new_files = []
+
+        result_list = []
+        extracted_class_files = []
         supplementary_files = []
-        imp_res_list = []
-        res_list = []
+        important_result_list = []
 
-        if request.file_type == "java/jar":
-            self.decompile_jar(temp_filename, decompiled_dir)
-            if self.jar_extract(temp_filename, extract_dir):
-                # Analysis properties
-                self.classloader_found = 0
-                self.security_found = 0
-                self.url_found = 0
-                self.runtime_found = 0
-                self.applet_found = 0
+        # Analysis properties
+        classloader_found = 0
+        security_found = 0
+        url_found = 0
+        runtime_found = 0
+        applet_found = 0
 
-                self.manifest_tags = []
-                self.signature_block_certs = []
+        manifest_tags = []
+        signature_block_certs = []
+        unique_headers_and_files = {}
+        embedded_pes = []
+        launchable_files = []
 
-                self.num_unique_headers = {}
-                self.embedded_pes = []
-                self.launchable_files = []
+        # decompile java/jar to the decompiled_dir
+        self.decompile_jar(temp_filename, decompiled_dir)
+        # extract files in jar
+        self.jar_extract(temp_filename, extract_dir)
 
-                def analyze_file(root, cf, file_res, imp_res_list, supplementary_files, decompiled_dir, extract_dir):
-                    cur_file_path = os.path.join(root.decode("utf-8"), cf.decode("utf-8"))
-                    with open(cur_file_path, "rb") as cur_file:
-                        start_bytes = cur_file.read(24)
+        # task for analyzing each file
+        def analyze_file(root_dir, current_file):
+            cur_file_path = os.path.join(root_dir.decode("utf-8"), current_file.decode("utf-8"))
 
-                        ##############################
-                        # Executables in JAR
-                        ##############################
-                        cur_ext = os.path.splitext(cf)[1][1:].upper()
-                        if start_bytes[:2] == b"MZ":
-                            self.embedded_pes.append(cur_file_path)
-                        ##############################
-                        # Launchable in JAR
-                        ##############################
-                        elif cur_ext in G_LAUNCHABLE_EXTENSIONS:
-                            self.launchable_files.append(cur_file_path)
+            file_result = FileResult.empty_file_result(cur_file_path)
 
-                        if cur_file_path.upper().endswith(".CLASS"):
-                            self.analyse_class_file(
-                                file_res,
-                                cf,
-                                cur_file,
-                                cur_file_path,
-                                start_bytes,
-                                imp_res_list,
-                                supplementary_files,
-                                decompiled_dir,
-                                extract_dir
-                            )
+            with open(cur_file_path, "rb") as cur_file:
+                start_bytes = cur_file.read(256)
 
+                ##############################
+                # Executables in JAR
+                ##############################
+                cur_ext = os.path.splitext(current_file)[1][1:].upper()
+                if start_bytes[:2] == b"MZ":
+                    file_result.embedded_pes = True
+                ##############################
+                # Launchable in JAR
+                ##############################
+                elif cur_ext in G_LAUNCHABLE_EXTENSIONS:
+                    file_result.launchable_file = True
 
-                for root, _, files in os.walk(extract_dir.encode("utf-8")):
-                    logging.info(f"Extracted: {root} - {files}")
+                ##############################
+                # analyze CLASS file
+                ##############################
+                if cur_file_path.upper().endswith(".CLASS"):
+                    # analyze class file
+                    if start_bytes[:4] == b"\xca\xfe\xba\xbe":
+                        cur_file.seek(0)
 
-                    # if the META-INF folder is encountered
-                    if root.upper().endswith(b"META-INF"):  # only top level meta
-                        self.analyse_meta_information(root, supplementary_files)
-                        continue
+                        cur_file_full_data = cur_file.read()
 
-                    with ThreadPoolExecutor() as executor:
-                        for cf in files:
-                            executor.submit(
-                                analyze_file,
-                                root,
-                                cf,
-                                file_res,
-                                imp_res_list,
-                                supplementary_files,
-                                decompiled_dir,
-                                extract_dir,
-                            )
+                        # Analyse file for suspicious functions
+                        file_result.interesting_class_attributes = self.do_class_analysis(cur_file_full_data)
+                        if file_result.interesting_class_attributes.is_interesting():
+                            path, name, desc = self.decompile_class_file(cur_file_path, decompiled_dir, extract_dir)
+                            if path:
+                                file_result.extracted_class_file = (path, name, desc)
 
+                    else:
+                        # Could not deobfuscate
+                        # store the first 265 byte of file data to identify unique files
+                        file_result.header_hex = hexdump(start_bytes)
 
+            return file_result
 
+        # Walk through each file and analyze them separately
+        for root_dir, _, files in os.walk(extract_dir.encode("utf-8")):
+            logging.info(f"Extracted: {root_dir} - {files}")
+            # if the META-INF folder is encountered
+            if root_dir.upper().endswith(b"META-INF"):  # only top level meta
+                mani_tags, certs, output_files = self.analyse_meta_information(root_dir)
+                supplementary_files.extend(output_files)
+                manifest_tags.extend(mani_tags)
+                signature_block_certs.extend(certs)
+                continue
+            # analyze each file using a thread pool
+            with ThreadPoolExecutor() as executor:
+                file_futures = [executor.submit(analyze_file, root_dir, cur_file) for cur_file in files]
 
-                # if irregular header byte exist, create result section for each unique header
-                for hex_256 in self.num_unique_headers.keys():
-                    ob_res = dict(
-                        title_text=f"Java class file(s) doesn't have the normal class files magic bytes. "
-                        "The file was re-submitted for analysis. Here are the first 256 bytes:",
-                        body=hex_256,
-                        body_format=BODY_FORMAT.MEMORY_DUMP,
-                        heur_id=3,
-                        tags=[("file.behavior", "Suspicious Java Class")],
-                        files=self.num_unique_headers[hex_256],
-                    )
+                for future in concurrent.futures.as_completed(file_futures):
+                    file_result = future.result()
 
-                    imp_res_list.append(ob_res)
+                    classloader_found += int(file_result.interesting_class_attributes.classloader_found)
+                    security_found += int(file_result.interesting_class_attributes.security_found)
+                    url_found += int(file_result.interesting_class_attributes.url_found)
+                    runtime_found += int(file_result.interesting_class_attributes.runtime_found)
+                    applet_found += int(file_result.interesting_class_attributes.applet_found)
 
-                # compile embeded files into a single heuristic
-                if len(self.embedded_pes) > 1:
-                    imp_res_list.append(dict(
-                        title_text="Embedded executable files found. There may be a malicious intent.",
-                        heur_id=1,
-                        tags=[("file.behavior", "Embedded PE")],
-                        files = self.embedded_pes,
-                        score_condition=APPLET_MZ,
-                    ))
+                    if file_result.header_hex:
+                        unique_header_files = unique_headers_and_files.get(file_result.header_hex, list())
+                        unique_header_files.append(file_result.file_path)
+                        unique_headers_and_files[file_result.header_hex] = unique_header_files
 
-                if len(self.launchable_files) > 1:
-                    imp_res_list.append(dict(
-                        title_text="Launch-able file type(s) found. There may be a malicious intent.",
-                        heur_id=2,
-                        tags=[("file.behavior", "Launch-able file in JAR")],
-                        files = self.launchable_files,
-                        score_condition=APPLET_MZ,
-                    ))
+                    if file_result.embedded_pes:
+                        embedded_pes.append(file_result.file_path)
+                    if file_result.launchable_file:
+                        launchable_files.append(file_result.file_path)
 
+                    if file_result.extracted_class_file[0]:
+                        extracted_class_files.append(file_result.extracted_class_file)
 
-                res = ResultSection("Analysis of the JAR file")
-                res_meta = ResultSection("[Meta Information]")
-                if len(self.manifest_tags) > 0:
-                    res_manifest = ResultSection("Manifest File Information Extract", parent=res_meta)
-                    for tag, val in self.manifest_tags:
-                        res_manifest.add_tag(tag, val)
+        # if irregular header byte exist, create result section for each unique header
+        for hex_256 in unique_headers_and_files.keys():
+            ob_res = dict(
+                title_text="Java class file(s) doesn't have the normal class files magic bytes. "
+                "The file was re-submitted for analysis. Here are the first 256 bytes:",
+                body=hex_256,
+                body_format=BODY_FORMAT.MEMORY_DUMP,
+                heur_id=Heuristic(3),
+                tags=[("file.behavior", "Suspicious Java Class")],
+                files=unique_headers_and_files[hex_256],
+            )
 
-                for res_cert in self.signature_block_certs:
-                    res_meta.add_subsection(res_cert)
+            important_result_list.append(ob_res)
 
-                if res_meta.subsections:
-                    res.add_subsection(res_meta)
-
-                if (
-                    self.runtime_found > 0
-                    or self.applet_found > 0
-                    or self.classloader_found > 0
-                    or self.security_found > 0
-                    or self.url_found > 0
-                ):
-                    res.add_line("All suspicious class files were saved as supplementary files.")
-
-                res_class = ResultSection("[Suspicious classes]")
-
-                if self.runtime_found > 0:
-                    ResultSection(
-                        "Runtime Found",
-                        body=f"java/lang/Runtime: {self.runtime_found}",
-                        heuristic=Heuristic(10),
-                        parent=res_class,
-                    )
-
-                if self.applet_found > 0:
-                    ResultSection(
-                        "Applet Found",
-                        body=f"java/applet/Applet: {self.applet_found}",
-                        heuristic=Heuristic(6),
-                        parent=res_class,
-                    )
-
-                if self.classloader_found > 0:
-                    ResultSection(
-                        "Classloader Found",
-                        body=f"java/lang/ClassLoader: {self.classloader_found}",
-                        heuristic=Heuristic(7),
-                        parent=res_class,
-                    )
-
-                if self.security_found > 0:
-                    ResultSection(
-                        "Security Found",
-                        body=f"java/security/*: {self.security_found}",
-                        heuristic=Heuristic(8),
-                        parent=res_class,
-                    )
-
-                if self.url_found > 0:
-                    ResultSection(
-                        "URL Found", body=f"java/net/URL: {self.url_found}", heuristic=Heuristic(9), parent=res_class
-                    )
-
-
-                if res_class.subsections:
-                    res.add_subsection(res_class)
-
-                if res.subsections:
-                    res_list.append(res)
-
-        # Add results if any
-        self.recurse_add_res(file_res, imp_res_list, new_files)
-        for res in res_list:
-            file_res.add_section(res)
-
-        # Submit embedded files
-        if len(new_files) > 0:
-            new_files = sorted(list(set(new_files)))
-            txt = f"Extracted from 'JAR' file {filename}"
-            for embed in new_files:
-                request.add_extracted(
-                    embed,
-                    embed.replace(extract_dir + "/", "").replace(decompiled_dir + "/", ""),
-                    txt,
-                    safelist_interface=self.api_interface,
+        # compile embedded files into a single heuristic
+        if embedded_pes:
+            important_result_list.append(
+                dict(
+                    title_text="Embedded executable files found. There may be a malicious intent.",
+                    heur_id=(Heuristic(1) if applet_found > 0 else Heuristic(2)),
+                    tags=[("file.behavior", "Embedded PE")],
+                    files=embedded_pes,
+                    file_desc="Embedded executable file. ",
                 )
+            )
 
-        if len(supplementary_files) > 0:
-            supplementary_files = sorted(list(set(supplementary_files)))
-            for path, name, desc in supplementary_files:
-                request.add_supplementary(path, name, desc)
-
-    def recurse_add_res(self, file_res, res_list, new_files, parent=None):
-        for res_dic in res_list:
-            # Check if condition is OK
-            if self.pass_condition(res_dic.get("condition", None)):
-                res = ResultSection(
-                    res_dic["title_text"],
-                    classification=res_dic.get("classification", Classification.UNRESTRICTED),
-                    parent=parent,
-                    body_format=res_dic.get("body_format", BODY_FORMAT.TEXT),
+        if launchable_files:
+            important_result_list.append(
+                dict(
+                    title_text="Launch-able file type(s) found. There may be a malicious intent.",
+                    heur_id=(Heuristic(3) if applet_found > 0 else Heuristic(4)),
+                    tags=[("file.behavior", "Launch-able file in JAR")],
+                    file_desc="Launchable file. ",
+                    files=launchable_files,
                 )
-                heur_id = self.heuristic_alteration(res_dic.get("score_condition", None), res_dic["heur_id"])
-                res.set_heuristic(heur_id)
+            )
 
-                # Add Tags
-                tags = res_dic.get("tags", [])
-                for res_tag in tags:
-                    res.add_tag(res_tag[0], res_tag[1])
+        root_analysis_result = ResultSection("Analysis of the JAR file")
+        res_meta = ResultSection("[Meta Information]")
 
-                # Add body
-                body = res_dic.get("body", None)
-                if body:
-                    res.set_body(body)
+        if manifest_tags:
+            res_manifest = ResultSection("Manifest File Information Extract", parent=res_meta)
+            for tag, val in manifest_tags:
+                res_manifest.add_tag(tag, val)
 
-                # File for resubmit
-                files = res_dic.get("files", [])
-                for res_file in files:
-                    if isinstance(res_file, tuple):
-                        res_file = res_file[1]
-                    new_files.append(res_file)
+        for res_cert in signature_block_certs:
+            res_meta.add_subsection(res_cert)
 
-                # Add to file res if root result
-                if parent is None:
-                    file_res.add_section(res)
+        if res_meta.subsections:
+            root_analysis_result.add_subsection(res_meta)
 
-    def pass_condition(self, condition):
-        if condition is None:
-            return True
-        if condition == APPLET:
-            if self.applet_found > 0:
-                return True
+        if runtime_found > 0 or applet_found > 0 or classloader_found > 0 or security_found > 0 or url_found > 0:
+            root_analysis_result.add_line("All suspicious class files were saved as supplementary files.")
 
-        return False
+        res_class = ResultSection("[Suspicious classes]")
 
-    def heuristic_alteration(self, score_condition, heur_id):
-        if score_condition is None:
-            return heur_id
+        if runtime_found > 0:
+            ResultSection(
+                "Runtime Found",
+                body=f"java/lang/Runtime: {runtime_found}",
+                heuristic=Heuristic(10),
+                parent=res_class,
+            )
 
-        if score_condition == APPLET_MZ:
-            if self.applet_found > 0:
-                return heur_id
-            else:
-                return heur_id + 1
+        if applet_found > 0:
+            ResultSection(
+                "Applet Found",
+                body=f"java/applet/Applet: {applet_found}",
+                heuristic=Heuristic(6),
+                parent=res_class,
+            )
+
+        if classloader_found > 0:
+            ResultSection(
+                "Classloader Found",
+                body=f"java/lang/ClassLoader: {classloader_found}",
+                heuristic=Heuristic(7),
+                parent=res_class,
+            )
+
+        if security_found > 0:
+            ResultSection(
+                "Security Found",
+                body=f"java/security/*: {security_found}",
+                heuristic=Heuristic(8),
+                parent=res_class,
+            )
+
+        if url_found > 0:
+            ResultSection(
+                "URL Found", body=f"java/net/URL: {url_found}", heuristic=Heuristic(9), parent=root_analysis_result
+            )
+
+        if res_class.subsections:
+            result_list.append(res_class)
+
+        if root_analysis_result.subsections:
+            result_list.append(root_analysis_result)
+
+        # First stored important files with PE or launchable file in extracted file
+        important_output_files = self.recurse_add_result(request.result, important_result_list)
+
+        for desc, file in important_output_files:
+            file_description = desc + f"Extracted from 'JAR' file {filename}"
+            request.add_extracted(
+                file,
+                file.replace(extract_dir + "/", "").replace(decompiled_dir + "/", ""),
+                file_description,
+                safelist_interface=self.api_interface,
+            )
+        # put as many decompiled class file in extracted as possible and leave the rest in supplementary
+        max_extracted = (request.task.max_extracted - len(important_output_files)) - 1
+        sorted_class_files = sorted(list(set(extracted_class_files)))
+        max_class_extracted = 0 if max_extracted < 0 else len(sorted_class_files)
+
+        for path, name, desc in sorted_class_files[:max_class_extracted]:
+            request.add_extracted(path, name, desc, safelist_interface=self.api_interface)
+
+        supplementary_files.extend(sorted_class_files[max_class_extracted:])
+        for path, name, desc in supplementary_files:
+            request.add_supplementary(path, name, desc)
+
+        for res in result_list:
+            request.result.add_section(res)
+
+    def recurse_add_result(self, request_result, result_list, parent=None):
+        output_files = []
+
+        file_set = set()
+
+        for result_desc in result_list:
+            res = ResultSection(
+                result_desc["title_text"],
+                classification=result_desc.get("classification", Classification.UNRESTRICTED),
+                parent=parent,
+                body_format=result_desc.get("body_format", BODY_FORMAT.TEXT),
+                heuristic=result_desc["heur_id"],
+            )
+
+            # Add Tags
+            tags = result_desc.get("tags", [])
+            for res_tag in tags:
+                res.add_tag(res_tag[0], res_tag[1])
+
+            # Add body
+            body = result_desc.get("body", None)
+            if body:
+                res.set_body(body)
+
+            # File for resubmit
+            files = result_desc.get("files", [])
+            desc = result_desc.get("file_desc", "")
+            for res_file in files:
+                # make sure we are only adding unique file
+                if res_file in file_set:
+                    continue
+                output_files.append((desc, res_file))
+                file_set.add(res_file)
+
+            # Add to file res if root result
+            if parent is None:
+                request_result.add_section(res)
+
+        return output_files

--- a/espresso/espresso.py
+++ b/espresso/espresso.py
@@ -276,7 +276,10 @@ class Espresso(ServiceBase):
                 stdout = keytool_printcert(cur_file)
 
                 if stdout:  # if stdout isn't None then the file must have been a certificate
-                    certs, output_files = self.validate_certs(stdout, cur_file)
+                    val_certs, val_output_files = self.validate_certs(stdout, cur_file)
+
+                    certs.extend(val_certs)
+                    output_files.extend(val_output_files)
 
         return manifest_tags, certs, output_files
 
@@ -438,7 +441,6 @@ class Espresso(ServiceBase):
                 )
             )
 
-        root_analysis_result = ResultSection("Analysis of the JAR file")
         res_meta = ResultSection("[Meta Information]")
 
         if manifest_tags:
@@ -450,10 +452,8 @@ class Espresso(ServiceBase):
             res_meta.add_subsection(res_cert)
 
         if res_meta.subsections:
-            root_analysis_result.add_subsection(res_meta)
+            result_list.append(res_meta)
 
-        if runtime_found > 0 or applet_found > 0 or classloader_found > 0 or security_found > 0 or url_found > 0:
-            root_analysis_result.add_line("All suspicious class files were saved as supplementary files.")
 
         res_class = ResultSection("[Suspicious classes]")
 
@@ -490,15 +490,10 @@ class Espresso(ServiceBase):
             )
 
         if url_found > 0:
-            ResultSection(
-                "URL Found", body=f"java/net/URL: {url_found}", heuristic=Heuristic(9), parent=root_analysis_result
-            )
+            ResultSection("URL Found", body=f"java/net/URL: {url_found}", heuristic=Heuristic(9), parent=res_class)
 
         if res_class.subsections:
             result_list.append(res_class)
-
-        if root_analysis_result.subsections:
-            result_list.append(root_analysis_result)
 
         # attach result section to relevant files. Get interesting files to add to extracted
         important_output_files = self.recurse_add_result(request.result, important_result_list)
@@ -514,7 +509,7 @@ class Espresso(ServiceBase):
         # put as many decompiled class file in extracted as possible and leave the rest in supplementary
         max_extracted = (request.task.max_extracted - len(important_output_files)) - 1
         sorted_class_files = sorted(list(set(extracted_class_files)))
-        max_class_extracted = 0 if max_extracted < 0 else len(sorted_class_files)
+        max_class_extracted = 0 if max_extracted < 0 else min(len(sorted_class_files), max_extracted)
 
         for path, name, desc in sorted_class_files[:max_class_extracted]:
             request.add_extracted(path, name, desc, safelist_interface=self.api_interface)

--- a/espresso/file_result.py
+++ b/espresso/file_result.py
@@ -25,12 +25,18 @@ class FileResult():
     embedded_pes: bool
     launchable_file: bool
     interesting_class_attributes: ClassAttributes
-    header_hex: str | None
+    header_hex: str
     extracted_class_file: Tuple
     empty_file: bool
 
     @staticmethod
     def empty_file_result(file_path):
-        return FileResult(file_path=file_path, embedded_pes=False, launchable_file=False,
-                          interesting_class_attributes=ClassAttributes.empty_class_attributes(),
-                          header_hex=None, extracted_class_file=(None, None, None), empty_file=False)
+        return FileResult(
+            file_path=file_path,
+            embedded_pes=False,
+            launchable_file=False,
+            interesting_class_attributes=ClassAttributes.empty_class_attributes(),
+            header_hex="",
+            extracted_class_file=(None, None, None),
+            empty_file=False,
+        )

--- a/espresso/file_result.py
+++ b/espresso/file_result.py
@@ -27,7 +27,6 @@ class FileResult():
     interesting_class_attributes: ClassAttributes
     header_hex: str
     extracted_class_file: Tuple
-    empty_file: bool
 
     @staticmethod
     def empty_file_result(file_path):
@@ -38,5 +37,4 @@ class FileResult():
             interesting_class_attributes=ClassAttributes.empty_class_attributes(),
             header_hex="",
             extracted_class_file=(None, None, None),
-            empty_file=False,
         )

--- a/espresso/file_result.py
+++ b/espresso/file_result.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass
+from typing import Tuple
+
+
+@dataclass
+class ClassAttributes():
+    applet_found: bool
+    classloader_found: bool
+    security_found: bool
+    url_found: bool
+    runtime_found: bool
+
+    def is_interesting(self):
+        return self.applet_found or self.classloader_found or self.security_found \
+            or self.url_found or self.runtime_found
+
+    @staticmethod
+    def empty_class_attributes():
+        return ClassAttributes(False, False, False, False, False)
+
+
+@dataclass
+class FileResult():
+    file_path: str
+    embedded_pes: bool
+    launchable_file: bool
+    interesting_class_attributes: ClassAttributes
+    header_hex: str | None
+    extracted_class_file: Tuple
+    empty_file: bool
+
+    @staticmethod
+    def empty_file_result(file_path):
+        return FileResult(file_path=file_path, embedded_pes=False, launchable_file=False,
+                          interesting_class_attributes=ClassAttributes.empty_class_attributes(),
+                          header_hex=None, extracted_class_file=(None, None, None), empty_file=False)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
 assemblyline
 assemblyline-service-utilities
+requests-mock
 pytest

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,3 @@
 assemblyline
 assemblyline-service-utilities
-requests-mock
 pytest

--- a/tests/results/121723c86cb7b24ad90f68dde901fe6dec0e337d8d3233cd5ef0d58f07d47487/result.json
+++ b/tests/results/121723c86cb7b24ad90f68dde901fe6dec0e337d8d3233cd5ef0d58f07d47487/result.json
@@ -52,7 +52,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "Owner: CN=root, OU=root, O=root, L=root, ST=root, C=CA\nIssuer: CN=root, OU=root, O=root, L=root, ST=root, C=CA\nSerial number: 5f0ac1d5\nValid from: Wed Apr 14 17:37:49 UTC 2021 until: Tue Jul 13 17:37:49 UTC 2021\nCertificate fingerprints:\n\t SHA1: 0D:A1:EA:85:EB:B1:7A:78:16:A3:50:6C:2C:15:12:39:4E:25:32:09\n\t SHA256: E0:FB:37:DF:97:42:75:72:F4:69:EA:C5:97:00:33:9B:2D:C3:4A:9A:1D:31:A9:B4:AD:87:09:91:5D:81:1A:B7\nSignature algorithm name: SHA256withDSA\nSubject Public Key Algorithm: 2048-bit DSA key\nVersion: 3\n\nExtensions: \n\n#1: ObjectId: 2.5.29.19 Criticality=true\nBasicConstraints:[\n  CA:true\n  PathLen:2147483647\n]\n\n#2: ObjectId: 2.5.29.14 Criticality=false\nSubjectKeyIdentifier [\nKeyIdentifier [\n0000: 9D 76 79 BA 97 17 06 07   75 A6 5C E1 E6 98 09 F0  .vy.....u.\\.....\n0010: D8 42 F6 C1                                        .B..\n]\n]",
+        "body": "Owner: CN=root, OU=root, O=root, L=root, ST=root, C=CA\nIssuer: CN=root, OU=root, O=root, L=root, ST=root, C=CA\nSerial number: 5f0ac1d5\nValid from: Wed Apr 14 17:37:49 UTC 2021 until: Tue Jul 13 17:37:49 UTC 2021\nCertificate fingerprints:\n\t SHA1: 0D:A1:EA:85:EB:B1:7A:78:16:A3:50:6C:2C:15:12:39:4E:25:32:09\n\t SHA256: E0:FB:37:DF:97:42:75:72:F4:69:EA:C5:97:00:33:9B:2D:C3:4A:9A:1D:31:A9:B4:AD:87:09:91:5D:81:1A:B7\nSignature algorithm name: SHA256withDSA\nSubject Public Key Algorithm: 2048-bit DSA key\nVersion: 3\n\nExtensions: \n\n#1: ObjectId: 2.5.29.19 Criticality=true\nBasicConstraints:[\n  CA:true\n  PathLen: no limit\n]\n\n#2: ObjectId: 2.5.29.14 Criticality=false\nSubjectKeyIdentifier [\nKeyIdentifier [\n0000: 9D 76 79 BA 97 17 06 07   75 A6 5C E1 E6 98 09 F0  .vy.....u.\\.....\n0010: D8 42 F6 C1                                        .B..\n]\n]",
         "body_config": {},
         "body_format": "MEMORY_DUMP",
         "classification": "TLP:C",
@@ -162,24 +162,11 @@
       },
       {
         "auto_collapse": false,
-        "body": null,
-        "body_config": {},
-        "body_format": "TEXT",
-        "classification": "TLP:C",
-        "depth": 1,
-        "heuristic": null,
-        "promote_to": null,
-        "tags": {},
-        "title_text": "[Suspicious classes]",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
         "body": "java/net/URL: 2",
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",
-        "depth": 2,
+        "depth": 1,
         "heuristic": {
           "attack_ids": [],
           "frequency": 1,
@@ -196,8 +183,7 @@
     ]
   },
   "files": {
-    "extracted": [],
-    "supplementary": [
+    "extracted": [
       {
         "name": "helper.java",
         "sha256": "21bf1abe2ad7612d67347613bd238850a488acbaef753134577623e2dfe61406"
@@ -205,7 +191,9 @@
       {
         "name": "main.java",
         "sha256": "69b8b383d59d55c0e6bbfdc4d0ed793671089da3390ade99dd06853b0cb1de12"
-      },
+      }
+    ],
+    "supplementary": [
       {
         "name": "SERVER.DSA",
         "sha256": "8f4552e144d009d46dfefcd6498efb9e40134a21543dd00e39e5b6d8001b33c0"

--- a/tests/results/121723c86cb7b24ad90f68dde901fe6dec0e337d8d3233cd5ef0d58f07d47487/result.json
+++ b/tests/results/121723c86cb7b24ad90f68dde901fe6dec0e337d8d3233cd5ef0d58f07d47487/result.json
@@ -5,24 +5,11 @@
     "sections": [
       {
         "auto_collapse": false,
-        "body": "All suspicious class files were saved as supplementary files.",
-        "body_config": {},
-        "body_format": "TEXT",
-        "classification": "TLP:C",
-        "depth": 0,
-        "heuristic": null,
-        "promote_to": null,
-        "tags": {},
-        "title_text": "Analysis of the JAR file",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
         "body": null,
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",
-        "depth": 1,
+        "depth": 0,
         "heuristic": null,
         "promote_to": null,
         "tags": {},
@@ -35,7 +22,7 @@
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",
-        "depth": 2,
+        "depth": 1,
         "heuristic": null,
         "promote_to": null,
         "tags": {
@@ -56,7 +43,7 @@
         "body_config": {},
         "body_format": "MEMORY_DUMP",
         "classification": "TLP:C",
-        "depth": 2,
+        "depth": 1,
         "heuristic": null,
         "promote_to": null,
         "tags": {
@@ -86,7 +73,7 @@
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",
-        "depth": 3,
+        "depth": 2,
         "heuristic": {
           "attack_ids": [],
           "frequency": 1,
@@ -106,7 +93,7 @@
         "body_config": {},
         "body_format": "MEMORY_DUMP",
         "classification": "TLP:C",
-        "depth": 2,
+        "depth": 1,
         "heuristic": null,
         "promote_to": null,
         "tags": {
@@ -136,7 +123,7 @@
         "body_config": {},
         "body_format": "MEMORY_DUMP",
         "classification": "TLP:C",
-        "depth": 2,
+        "depth": 1,
         "heuristic": null,
         "promote_to": null,
         "tags": {
@@ -158,6 +145,19 @@
           }
         },
         "title_text": "Certificate Analysis",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": null,
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 0,
+        "heuristic": null,
+        "promote_to": null,
+        "tags": {},
+        "title_text": "[Suspicious classes]",
         "zeroize_on_tag_safe": false
       },
       {

--- a/tests/results/4005216ddf9e092bddda8a78f0babe94746632ef6a64793e1fa0e94f1538a49c/result.json
+++ b/tests/results/4005216ddf9e092bddda8a78f0babe94746632ef6a64793e1fa0e94f1538a49c/result.json
@@ -39,19 +39,6 @@
         "heuristic": null,
         "promote_to": null,
         "tags": {},
-        "title_text": "Analysis of the JAR file",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": null,
-        "body_config": {},
-        "body_format": "TEXT",
-        "classification": "TLP:C",
-        "depth": 1,
-        "heuristic": null,
-        "promote_to": null,
-        "tags": {},
         "title_text": "[Meta Information]",
         "zeroize_on_tag_safe": false
       },
@@ -61,7 +48,7 @@
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",
-        "depth": 2,
+        "depth": 1,
         "heuristic": null,
         "promote_to": null,
         "tags": {
@@ -84,35 +71,43 @@
   "files": {
     "extracted": [
       {
-        "name": "kingDavid/0.class/caesium_26.class",
+        "name": "kingDavid/9.class/caesium_26.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
-        "name": "kingDavid/0.class/caesium_27.class",
+        "name": "kingDavid/9.class/caesium_25.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
-        "name": "kingDavid/00.class/caesium_24.class",
+        "name": "kingDavid/9.class/caesium_30.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
-        "name": "kingDavid/00.class/caesium_25.class",
+        "name": "kingDavid/9.class/caesium_27.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
-        "name": "kingDavid/00.class/caesium_26.class",
+        "name": "kingDavid/9.class/caesium_29.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
-        "name": "kingDavid/00.class/caesium_27.class",
+        "name": "kingDavid/9.class/caesium_24.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
-        "name": "kingDavid/00.class/caesium_30.class",
+        "name": "kingDavid/9.class/caesium_31.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
-        "name": "kingDavid/00.class/caesium_31.class",
+        "name": "kingDavid/9.class/caesium_28.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/01.class/caesium_27.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/01.class/caesium_26.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
@@ -124,219 +119,7 @@
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
-        "name": "kingDavid/01.class/caesium_26.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/01.class/caesium_27.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
         "name": "kingDavid/01.class/caesium_31.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/1.class/caesium_24.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/1.class/caesium_25.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/1.class/caesium_26.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/1.class/caesium_27.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/10.class/caesium_27.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/11.class/caesium_24.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/11.class/caesium_25.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/11.class/caesium_26.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/11.class/caesium_27.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/11.class/caesium_28.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/11.class/caesium_29.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/11.class/caesium_30.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/11.class/caesium_31.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/2.class/caesium_24.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/2.class/caesium_25.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/2.class/caesium_26.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/2.class/caesium_27.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/2.class/caesium_28.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/2.class/caesium_29.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/2.class/caesium_30.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/2.class/caesium_31.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/20.class/caesium_25.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/20.class/caesium_26.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/20.class/caesium_27.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/21.class/caesium_24.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/21.class/caesium_25.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/21.class/caesium_26.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/21.class/caesium_27.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/21.class/caesium_30.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/21.class/caesium_31.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/3.class/caesium_27.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/30.class/caesium_18.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/30.class/caesium_19.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/30.class/caesium_24.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/30.class/caesium_25.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/30.class/caesium_26.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/30.class/caesium_27.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/30.class/caesium_28.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/30.class/caesium_29.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/30.class/caesium_30.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/30.class/caesium_31.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/31.class/caesium_25.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/31.class/caesium_26.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/31.class/caesium_27.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/4.class/caesium_24.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/4.class/caesium_25.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/4.class/caesium_26.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/4.class/caesium_27.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/4.class/caesium_29.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/4.class/caesium_30.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/4.class/caesium_31.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
@@ -349,98 +132,6 @@
       },
       {
         "name": "kingDavid/41.class/caesium_27.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/5.class/caesium_25.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/5.class/caesium_26.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/5.class/caesium_27.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/50.class/caesium_26.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/50.class/caesium_27.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/51.class/caesium_27.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/6.class/caesium_26.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/6.class/caesium_27.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/60.class/caesium_24.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/60.class/caesium_25.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/60.class/caesium_26.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/60.class/caesium_27.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/60.class/caesium_28.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/60.class/caesium_29.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/60.class/caesium_30.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/60.class/caesium_31.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/7.class/caesium_27.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/70.class/caesium_24.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/70.class/caesium_25.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/70.class/caesium_26.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/70.class/caesium_27.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/70.class/caesium_31.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/8.class/caesium_24.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
@@ -460,95 +151,59 @@
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
-        "name": "kingDavid/80.class/caesium_25.class",
+        "name": "kingDavid/8.class/caesium_24.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
-        "name": "kingDavid/80.class/caesium_26.class",
+        "name": "kingDavid/11.class/caesium_27.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
-        "name": "kingDavid/80.class/caesium_27.class",
+        "name": "kingDavid/11.class/caesium_26.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
-        "name": "kingDavid/9.class/caesium_24.class",
+        "name": "kingDavid/11.class/caesium_30.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
-        "name": "kingDavid/9.class/caesium_25.class",
+        "name": "kingDavid/11.class/caesium_31.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
-        "name": "kingDavid/9.class/caesium_26.class",
+        "name": "kingDavid/11.class/caesium_25.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
-        "name": "kingDavid/9.class/caesium_27.class",
+        "name": "kingDavid/11.class/caesium_24.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
-        "name": "kingDavid/9.class/caesium_28.class",
+        "name": "kingDavid/11.class/caesium_28.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
-        "name": "kingDavid/9.class/caesium_29.class",
+        "name": "kingDavid/11.class/caesium_29.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
-        "name": "kingDavid/9.class/caesium_30.class",
+        "name": "kingDavid/50.class/caesium_26.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
-        "name": "kingDavid/9.class/caesium_31.class",
+        "name": "kingDavid/50.class/caesium_27.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
-        "name": "kingDavid/90.class/caesium_19.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/90.class/caesium_24.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/90.class/caesium_25.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/90.class/caesium_26.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/90.class/caesium_27.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/90.class/caesium_28.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/90.class/caesium_29.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/90.class/caesium_30.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/90.class/caesium_31.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/FirstRun.class/caesium_24.class",
-        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-      },
-      {
-        "name": "kingDavid/FirstRun.class/caesium_25.class",
+        "name": "kingDavid/FirstRun.class/caesium_30.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
         "name": "kingDavid/FirstRun.class/caesium_26.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/FirstRun.class/caesium_25.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
@@ -560,11 +215,343 @@
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
-        "name": "kingDavid/FirstRun.class/caesium_30.class",
+        "name": "kingDavid/FirstRun.class/caesium_31.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       },
       {
-        "name": "kingDavid/FirstRun.class/caesium_31.class",
+        "name": "kingDavid/FirstRun.class/caesium_24.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/31.class/caesium_26.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/31.class/caesium_25.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/31.class/caesium_27.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/0.class/caesium_26.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/0.class/caesium_27.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/5.class/caesium_26.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/5.class/caesium_25.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/5.class/caesium_27.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/6.class/caesium_26.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/6.class/caesium_27.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/51.class/caesium_27.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/10.class/caesium_27.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/3.class/caesium_27.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/90.class/caesium_19.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/90.class/caesium_26.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/90.class/caesium_31.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/90.class/caesium_30.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/90.class/caesium_25.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/90.class/caesium_27.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/90.class/caesium_29.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/90.class/caesium_28.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/90.class/caesium_24.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/2.class/caesium_31.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/2.class/caesium_27.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/2.class/caesium_30.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/2.class/caesium_25.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/2.class/caesium_26.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/2.class/caesium_29.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/2.class/caesium_24.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/2.class/caesium_28.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/30.class/caesium_25.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/30.class/caesium_19.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/30.class/caesium_30.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/30.class/caesium_27.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/30.class/caesium_26.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/30.class/caesium_18.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/30.class/caesium_31.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/30.class/caesium_28.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/30.class/caesium_29.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/30.class/caesium_24.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/7.class/caesium_27.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/80.class/caesium_26.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/80.class/caesium_25.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/80.class/caesium_27.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/60.class/caesium_31.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/60.class/caesium_26.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/60.class/caesium_30.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/60.class/caesium_25.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/60.class/caesium_28.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/60.class/caesium_29.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/60.class/caesium_27.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/60.class/caesium_24.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/00.class/caesium_31.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/00.class/caesium_27.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/00.class/caesium_26.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/00.class/caesium_30.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/00.class/caesium_25.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/00.class/caesium_24.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/4.class/caesium_25.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/4.class/caesium_31.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/4.class/caesium_27.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/4.class/caesium_30.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/4.class/caesium_26.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/4.class/caesium_24.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/4.class/caesium_29.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/21.class/caesium_25.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/21.class/caesium_26.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/21.class/caesium_30.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/21.class/caesium_24.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/21.class/caesium_27.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/21.class/caesium_31.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/1.class/caesium_25.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/1.class/caesium_26.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/1.class/caesium_24.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/1.class/caesium_27.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/70.class/caesium_25.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/70.class/caesium_26.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/70.class/caesium_31.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/70.class/caesium_27.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/70.class/caesium_24.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/20.class/caesium_26.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/20.class/caesium_25.class",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+      },
+      {
+        "name": "kingDavid/20.class/caesium_27.class",
         "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
       }
     ],

--- a/tests/results/5ed84c810a55ce1581b706f0b481707d2404124ac31a9f3b16038c15a80cc8be/result.json
+++ b/tests/results/5ed84c810a55ce1581b706f0b481707d2404124ac31a9f3b16038c15a80cc8be/result.json
@@ -13,6 +13,82 @@
         "heuristic": null,
         "promote_to": null,
         "tags": {},
+        "title_text": "[Meta Information]",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": null,
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": null,
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Manifest File Information Extract",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "Owner: CN=Thomas W, OU=TFM, O=TFM, L=Manchester, ST=Greater Manchester, C=GB\nIssuer: CN=Thomas W, OU=TFM, O=TFM, L=Manchester, ST=Greater Manchester, C=GB\nSerial number: 53be0d7c\nValid from: Thu Jan 06 22:14:27 UTC 2022 until: Wed Apr 06 22:14:27 UTC 2022\nCertificate fingerprints:\n\t SHA1: 32:D1:42:D2:22:D0:A1:8C:9D:19:D5:B8:89:17:C7:47:7A:F1:CD:28\n\t SHA256: 03:3E:BA:44:19:96:4C:40:D1:E4:BF:0B:A9:0B:D4:FE:8A:6C:17:B9:64:AD:67:13:9C:1D:98:6C:70:CA:1F:88\nSignature algorithm name: SHA256withRSA\nSubject Public Key Algorithm: 2048-bit RSA key\nVersion: 3\n\nExtensions: \n\n#1: ObjectId: 2.5.29.14 Criticality=false\nSubjectKeyIdentifier [\nKeyIdentifier [\n0000: 15 84 6F 04 5F 1D 22 2D   10 C4 DE B7 E7 E7 3B DF  ..o._.\"-......;.\n0010: 04 2A 3B B3                                        .*;.\n]\n]",
+        "body_config": {},
+        "body_format": "MEMORY_DUMP",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": null,
+        "promote_to": null,
+        "tags": {
+          "cert": {
+            "issuer": [
+              "CN=Thomas W, OU=TFM, O=TFM, L=Manchester, ST=Greater Manchester, C=GB"
+            ],
+            "owner": [
+              "CN=Thomas W, OU=TFM, O=TFM, L=Manchester, ST=Greater Manchester, C=GB"
+            ],
+            "valid": {
+              "end": [
+                "Wed Apr 06 22:14:27 UTC 2022"
+              ],
+              "start": [
+                "Thu Jan 06 22:14:27 UTC 2022"
+              ]
+            }
+          }
+        },
+        "title_text": "Certificate Analysis",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": null,
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 2,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 11,
+          "score": 1,
+          "score_map": {},
+          "signatures": {}
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Certificate is self-signed",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": null,
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 0,
+        "heuristic": null,
+        "promote_to": null,
+        "tags": {},
         "title_text": "[Suspicious classes]",
         "zeroize_on_tag_safe": false
       },
@@ -74,95 +150,6 @@
         "promote_to": null,
         "tags": {},
         "title_text": "Security Found",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "All suspicious class files were saved as supplementary files.",
-        "body_config": {},
-        "body_format": "TEXT",
-        "classification": "TLP:C",
-        "depth": 0,
-        "heuristic": null,
-        "promote_to": null,
-        "tags": {},
-        "title_text": "Analysis of the JAR file",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": null,
-        "body_config": {},
-        "body_format": "TEXT",
-        "classification": "TLP:C",
-        "depth": 1,
-        "heuristic": null,
-        "promote_to": null,
-        "tags": {},
-        "title_text": "[Meta Information]",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": null,
-        "body_config": {},
-        "body_format": "TEXT",
-        "classification": "TLP:C",
-        "depth": 2,
-        "heuristic": null,
-        "promote_to": null,
-        "tags": {},
-        "title_text": "Manifest File Information Extract",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "Owner: CN=Thomas W, OU=TFM, O=TFM, L=Manchester, ST=Greater Manchester, C=GB\nIssuer: CN=Thomas W, OU=TFM, O=TFM, L=Manchester, ST=Greater Manchester, C=GB\nSerial number: 53be0d7c\nValid from: Thu Jan 06 22:14:27 UTC 2022 until: Wed Apr 06 22:14:27 UTC 2022\nCertificate fingerprints:\n\t SHA1: 32:D1:42:D2:22:D0:A1:8C:9D:19:D5:B8:89:17:C7:47:7A:F1:CD:28\n\t SHA256: 03:3E:BA:44:19:96:4C:40:D1:E4:BF:0B:A9:0B:D4:FE:8A:6C:17:B9:64:AD:67:13:9C:1D:98:6C:70:CA:1F:88\nSignature algorithm name: SHA256withRSA\nSubject Public Key Algorithm: 2048-bit RSA key\nVersion: 3\n\nExtensions: \n\n#1: ObjectId: 2.5.29.14 Criticality=false\nSubjectKeyIdentifier [\nKeyIdentifier [\n0000: 15 84 6F 04 5F 1D 22 2D   10 C4 DE B7 E7 E7 3B DF  ..o._.\"-......;.\n0010: 04 2A 3B B3                                        .*;.\n]\n]",
-        "body_config": {},
-        "body_format": "MEMORY_DUMP",
-        "classification": "TLP:C",
-        "depth": 2,
-        "heuristic": null,
-        "promote_to": null,
-        "tags": {
-          "cert": {
-            "issuer": [
-              "CN=Thomas W, OU=TFM, O=TFM, L=Manchester, ST=Greater Manchester, C=GB"
-            ],
-            "owner": [
-              "CN=Thomas W, OU=TFM, O=TFM, L=Manchester, ST=Greater Manchester, C=GB"
-            ],
-            "valid": {
-              "end": [
-                "Wed Apr 06 22:14:27 UTC 2022"
-              ],
-              "start": [
-                "Thu Jan 06 22:14:27 UTC 2022"
-              ]
-            }
-          }
-        },
-        "title_text": "Certificate Analysis",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": null,
-        "body_config": {},
-        "body_format": "TEXT",
-        "classification": "TLP:C",
-        "depth": 3,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 11,
-          "score": 1,
-          "score_map": {},
-          "signatures": {}
-        },
-        "promote_to": null,
-        "tags": {},
-        "title_text": "Certificate is self-signed",
         "zeroize_on_tag_safe": false
       },
       {

--- a/tests/results/5ed84c810a55ce1581b706f0b481707d2404124ac31a9f3b16038c15a80cc8be/result.json
+++ b/tests/results/5ed84c810a55ce1581b706f0b481707d2404124ac31a9f3b16038c15a80cc8be/result.json
@@ -5,10 +5,83 @@
     "sections": [
       {
         "auto_collapse": false,
+        "body": null,
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 0,
+        "heuristic": null,
+        "promote_to": null,
+        "tags": {},
+        "title_text": "[Suspicious classes]",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "java/lang/Runtime: 40",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 10,
+          "score": 50,
+          "score_map": {},
+          "signatures": {}
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Runtime Found",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "java/lang/ClassLoader: 5",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 7,
+          "score": 10,
+          "score_map": {},
+          "signatures": {}
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Classloader Found",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "java/security/*: 8",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 8,
+          "score": 10,
+          "score_map": {},
+          "signatures": {}
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Security Found",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
         "body": "All suspicious class files were saved as supplementary files.",
         "body_config": {},
         "body_format": "TEXT",
-        "classification": "TLP:CLEAR",
+        "classification": "TLP:C",
         "depth": 0,
         "heuristic": null,
         "promote_to": null,
@@ -21,7 +94,7 @@
         "body": null,
         "body_config": {},
         "body_format": "TEXT",
-        "classification": "TLP:CLEAR",
+        "classification": "TLP:C",
         "depth": 1,
         "heuristic": null,
         "promote_to": null,
@@ -34,7 +107,7 @@
         "body": null,
         "body_config": {},
         "body_format": "TEXT",
-        "classification": "TLP:CLEAR",
+        "classification": "TLP:C",
         "depth": 2,
         "heuristic": null,
         "promote_to": null,
@@ -47,7 +120,7 @@
         "body": "Owner: CN=Thomas W, OU=TFM, O=TFM, L=Manchester, ST=Greater Manchester, C=GB\nIssuer: CN=Thomas W, OU=TFM, O=TFM, L=Manchester, ST=Greater Manchester, C=GB\nSerial number: 53be0d7c\nValid from: Thu Jan 06 22:14:27 UTC 2022 until: Wed Apr 06 22:14:27 UTC 2022\nCertificate fingerprints:\n\t SHA1: 32:D1:42:D2:22:D0:A1:8C:9D:19:D5:B8:89:17:C7:47:7A:F1:CD:28\n\t SHA256: 03:3E:BA:44:19:96:4C:40:D1:E4:BF:0B:A9:0B:D4:FE:8A:6C:17:B9:64:AD:67:13:9C:1D:98:6C:70:CA:1F:88\nSignature algorithm name: SHA256withRSA\nSubject Public Key Algorithm: 2048-bit RSA key\nVersion: 3\n\nExtensions: \n\n#1: ObjectId: 2.5.29.14 Criticality=false\nSubjectKeyIdentifier [\nKeyIdentifier [\n0000: 15 84 6F 04 5F 1D 22 2D   10 C4 DE B7 E7 E7 3B DF  ..o._.\"-......;.\n0010: 04 2A 3B B3                                        .*;.\n]\n]",
         "body_config": {},
         "body_format": "MEMORY_DUMP",
-        "classification": "TLP:CLEAR",
+        "classification": "TLP:C",
         "depth": 2,
         "heuristic": null,
         "promote_to": null,
@@ -77,7 +150,7 @@
         "body": null,
         "body_config": {},
         "body_format": "TEXT",
-        "classification": "TLP:CLEAR",
+        "classification": "TLP:C",
         "depth": 3,
         "heuristic": {
           "attack_ids": [],
@@ -94,84 +167,11 @@
       },
       {
         "auto_collapse": false,
-        "body": null,
-        "body_config": {},
-        "body_format": "TEXT",
-        "classification": "TLP:CLEAR",
-        "depth": 1,
-        "heuristic": null,
-        "promote_to": null,
-        "tags": {},
-        "title_text": "[Suspicious classes]",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "java/lang/Runtime: 40",
-        "body_config": {},
-        "body_format": "TEXT",
-        "classification": "TLP:CLEAR",
-        "depth": 2,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 10,
-          "score": 50,
-          "score_map": {},
-          "signatures": {}
-        },
-        "promote_to": null,
-        "tags": {},
-        "title_text": "Runtime Found",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "java/lang/ClassLoader: 5",
-        "body_config": {},
-        "body_format": "TEXT",
-        "classification": "TLP:CLEAR",
-        "depth": 2,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 7,
-          "score": 10,
-          "score_map": {},
-          "signatures": {}
-        },
-        "promote_to": null,
-        "tags": {},
-        "title_text": "Classloader Found",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "java/security/*: 8",
-        "body_config": {},
-        "body_format": "TEXT",
-        "classification": "TLP:CLEAR",
-        "depth": 2,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 8,
-          "score": 10,
-          "score_map": {},
-          "signatures": {}
-        },
-        "promote_to": null,
-        "tags": {},
-        "title_text": "Security Found",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
         "body": "java/net/URL: 8",
         "body_config": {},
         "body_format": "TEXT",
-        "classification": "TLP:CLEAR",
-        "depth": 2,
+        "classification": "TLP:C",
+        "depth": 1,
         "heuristic": {
           "attack_ids": [],
           "frequency": 1,
@@ -188,8 +188,7 @@
     ]
   },
   "files": {
-    "extracted": [],
-    "supplementary": [
+    "extracted": [
       {
         "name": "club/thom/tfm/blacklist/TailRender.java",
         "sha256": "008d41a13edce7b9979fe9951f439312d296cb6250a2614b22ce67946faafc4e"
@@ -297,10 +296,6 @@
       {
         "name": "com/google/protobuf/BinaryWriter$SafeHeapWriter.java",
         "sha256": "95829c4a34c058fb2bf215defe5f2d6600f8083537029556bab88ebccabe7419"
-      },
-      {
-        "name": "TFM.RSA",
-        "sha256": "966bb17d84236e4fa1e735f3d71de7118d0d5086daecc1ae8d7ca2c97915d514"
       },
       {
         "name": "com/google/protobuf/GeneratedMessageInfoFactory.java",
@@ -413,6 +408,12 @@
       {
         "name": "com/google/protobuf/CodedInputStreamReader.java",
         "sha256": "fffdb898eeb09701037f8e80272e9d3dbdbb95617e03efc0cbb35f1cb1a3a133"
+      }
+    ],
+    "supplementary": [
+      {
+        "name": "TFM.RSA",
+        "sha256": "966bb17d84236e4fa1e735f3d71de7118d0d5086daecc1ae8d7ca2c97915d514"
       }
     ]
   },

--- a/tests/results/a4ad3e2da3090286b8985d4c20e1d944c5da5ab2b68785c94b02779eba47d403/result.json
+++ b/tests/results/a4ad3e2da3090286b8985d4c20e1d944c5da5ab2b68785c94b02779eba47d403/result.json
@@ -39,19 +39,6 @@
         "heuristic": null,
         "promote_to": null,
         "tags": {},
-        "title_text": "Analysis of the JAR file",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": null,
-        "body_config": {},
-        "body_format": "TEXT",
-        "classification": "TLP:C",
-        "depth": 1,
-        "heuristic": null,
-        "promote_to": null,
-        "tags": {},
         "title_text": "[Meta Information]",
         "zeroize_on_tag_safe": false
       },
@@ -61,7 +48,7 @@
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",
-        "depth": 2,
+        "depth": 1,
         "heuristic": null,
         "promote_to": null,
         "tags": {},
@@ -77,99 +64,7 @@
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
-        "name": "1.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
-        "name": "10.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
-        "name": "11.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
-        "name": "12.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
-        "name": "13.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
-        "name": "14.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
-        "name": "15.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
-        "name": "16.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
-        "name": "17.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
         "name": "18.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
-        "name": "19.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
-        "name": "2.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
-        "name": "20.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
-        "name": "21.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
-        "name": "22.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
-        "name": "23.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
-        "name": "24.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
-        "name": "25.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
-        "name": "26.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
-        "name": "27.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
-        "name": "28.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
-        "name": "29.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
-        "name": "3.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
-        "name": "30.temp",
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
@@ -177,31 +72,63 @@
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
+        "name": "28.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
+        "name": "56.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
+        "name": "25.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
+        "name": "44.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
+        "name": "26.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
+        "name": "16.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
+        "name": "15.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
         "name": "32.temp",
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
-        "name": "33.temp",
+        "name": "10.temp",
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
-        "name": "34.temp",
+        "name": "42.temp",
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
-        "name": "35.temp",
+        "name": "30.temp",
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
-        "name": "36.temp",
+        "name": "27.temp",
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
-        "name": "37.temp",
+        "name": "29.temp",
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
-        "name": "38.temp",
+        "name": "55.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
+        "name": "12.temp",
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
@@ -213,7 +140,7 @@
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
-        "name": "40.temp",
+        "name": "21.temp",
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
@@ -221,19 +148,27 @@
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
-        "name": "42.temp",
+        "name": "36.temp",
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
-        "name": "43.temp",
+        "name": "38.temp",
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
-        "name": "44.temp",
+        "name": "24.temp",
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
-        "name": "45.temp",
+        "name": "14.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
+        "name": "19.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
+        "name": "9.temp",
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
@@ -241,19 +176,19 @@
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
-        "name": "47.temp",
+        "name": "22.temp",
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
-        "name": "48.temp",
+        "name": "45.temp",
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
-        "name": "49.temp",
+        "name": "3.temp",
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
-        "name": "5.temp",
+        "name": "33.temp",
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
@@ -261,31 +196,23 @@
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
-        "name": "51.temp",
+        "name": "48.temp",
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
-        "name": "52.temp",
+        "name": "37.temp",
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
-        "name": "53.temp",
+        "name": "23.temp",
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
-        "name": "54.temp",
+        "name": "43.temp",
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
-        "name": "55.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
-        "name": "56.temp",
-        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
-      },
-      {
-        "name": "57.temp",
+        "name": "17.temp",
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
@@ -297,11 +224,71 @@
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
+        "name": "13.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
+        "name": "54.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
+        "name": "20.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
+        "name": "11.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
         "name": "8.temp",
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       },
       {
-        "name": "9.temp",
+        "name": "1.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
+        "name": "51.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
+        "name": "52.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
+        "name": "35.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
+        "name": "2.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
+        "name": "5.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
+        "name": "47.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
+        "name": "57.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
+        "name": "34.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
+        "name": "40.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
+        "name": "53.temp",
+        "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
+      },
+      {
+        "name": "49.temp",
         "sha256": "0ad1892a915fd08d77e4a2bc6973228a36a8085d6ce3db8dbfd373758ff13023"
       }
     ],

--- a/tests/results/b0c0b4deb907136e07ad587abc316b3fe93151efda285c7346c6f1180e390410/result.json
+++ b/tests/results/b0c0b4deb907136e07ad587abc316b3fe93151efda285c7346c6f1180e390410/result.json
@@ -13,92 +13,6 @@
         "heuristic": null,
         "promote_to": null,
         "tags": {},
-        "title_text": "[Suspicious classes]",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "java/lang/Runtime: 23",
-        "body_config": {},
-        "body_format": "TEXT",
-        "classification": "TLP:C",
-        "depth": 1,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 10,
-          "score": 50,
-          "score_map": {},
-          "signatures": {}
-        },
-        "promote_to": null,
-        "tags": {},
-        "title_text": "Runtime Found",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "java/lang/ClassLoader: 43",
-        "body_config": {},
-        "body_format": "TEXT",
-        "classification": "TLP:C",
-        "depth": 1,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 7,
-          "score": 10,
-          "score_map": {},
-          "signatures": {}
-        },
-        "promote_to": null,
-        "tags": {},
-        "title_text": "Classloader Found",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "java/security/*: 25",
-        "body_config": {},
-        "body_format": "TEXT",
-        "classification": "TLP:C",
-        "depth": 1,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 8,
-          "score": 10,
-          "score_map": {},
-          "signatures": {}
-        },
-        "promote_to": null,
-        "tags": {},
-        "title_text": "Security Found",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "All suspicious class files were saved as supplementary files.",
-        "body_config": {},
-        "body_format": "TEXT",
-        "classification": "TLP:C",
-        "depth": 0,
-        "heuristic": null,
-        "promote_to": null,
-        "tags": {},
-        "title_text": "Analysis of the JAR file",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": null,
-        "body_config": {},
-        "body_format": "TEXT",
-        "classification": "TLP:C",
-        "depth": 1,
-        "heuristic": null,
-        "promote_to": null,
-        "tags": {},
         "title_text": "[Meta Information]",
         "zeroize_on_tag_safe": false
       },
@@ -108,7 +22,7 @@
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",
-        "depth": 2,
+        "depth": 1,
         "heuristic": null,
         "promote_to": null,
         "tags": {
@@ -253,6 +167,79 @@
           }
         },
         "title_text": "Manifest File Information Extract",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": null,
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 0,
+        "heuristic": null,
+        "promote_to": null,
+        "tags": {},
+        "title_text": "[Suspicious classes]",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "java/lang/Runtime: 23",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 10,
+          "score": 50,
+          "score_map": {},
+          "signatures": {}
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Runtime Found",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "java/lang/ClassLoader: 43",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 7,
+          "score": 10,
+          "score_map": {},
+          "signatures": {}
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Classloader Found",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "java/security/*: 25",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 8,
+          "score": 10,
+          "score_map": {},
+          "signatures": {}
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Security Found",
         "zeroize_on_tag_safe": false
       },
       {

--- a/tests/results/b0c0b4deb907136e07ad587abc316b3fe93151efda285c7346c6f1180e390410/result.json
+++ b/tests/results/b0c0b4deb907136e07ad587abc316b3fe93151efda285c7346c6f1180e390410/result.json
@@ -5,10 +5,83 @@
     "sections": [
       {
         "auto_collapse": false,
+        "body": null,
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 0,
+        "heuristic": null,
+        "promote_to": null,
+        "tags": {},
+        "title_text": "[Suspicious classes]",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "java/lang/Runtime: 23",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 10,
+          "score": 50,
+          "score_map": {},
+          "signatures": {}
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Runtime Found",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "java/lang/ClassLoader: 43",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 7,
+          "score": 10,
+          "score_map": {},
+          "signatures": {}
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Classloader Found",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
+        "body": "java/security/*: 25",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 8,
+          "score": 10,
+          "score_map": {},
+          "signatures": {}
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "Security Found",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
         "body": "All suspicious class files were saved as supplementary files.",
         "body_config": {},
         "body_format": "TEXT",
-        "classification": "TLP:CLEAR",
+        "classification": "TLP:C",
         "depth": 0,
         "heuristic": null,
         "promote_to": null,
@@ -21,7 +94,7 @@
         "body": null,
         "body_config": {},
         "body_format": "TEXT",
-        "classification": "TLP:CLEAR",
+        "classification": "TLP:C",
         "depth": 1,
         "heuristic": null,
         "promote_to": null,
@@ -34,7 +107,7 @@
         "body": null,
         "body_config": {},
         "body_format": "TEXT",
-        "classification": "TLP:CLEAR",
+        "classification": "TLP:C",
         "depth": 2,
         "heuristic": null,
         "promote_to": null,
@@ -184,84 +257,11 @@
       },
       {
         "auto_collapse": false,
-        "body": null,
-        "body_config": {},
-        "body_format": "TEXT",
-        "classification": "TLP:CLEAR",
-        "depth": 1,
-        "heuristic": null,
-        "promote_to": null,
-        "tags": {},
-        "title_text": "[Suspicious classes]",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "java/lang/Runtime: 23",
-        "body_config": {},
-        "body_format": "TEXT",
-        "classification": "TLP:CLEAR",
-        "depth": 2,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 10,
-          "score": 50,
-          "score_map": {},
-          "signatures": {}
-        },
-        "promote_to": null,
-        "tags": {},
-        "title_text": "Runtime Found",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "java/lang/ClassLoader: 43",
-        "body_config": {},
-        "body_format": "TEXT",
-        "classification": "TLP:CLEAR",
-        "depth": 2,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 7,
-          "score": 10,
-          "score_map": {},
-          "signatures": {}
-        },
-        "promote_to": null,
-        "tags": {},
-        "title_text": "Classloader Found",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
-        "body": "java/security/*: 25",
-        "body_config": {},
-        "body_format": "TEXT",
-        "classification": "TLP:CLEAR",
-        "depth": 2,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 8,
-          "score": 10,
-          "score_map": {},
-          "signatures": {}
-        },
-        "promote_to": null,
-        "tags": {},
-        "title_text": "Security Found",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
         "body": "java/net/URL: 42",
         "body_config": {},
         "body_format": "TEXT",
-        "classification": "TLP:CLEAR",
-        "depth": 2,
+        "classification": "TLP:C",
+        "depth": 1,
         "heuristic": {
           "attack_ids": [],
           "frequency": 1,
@@ -278,8 +278,7 @@
     ]
   },
   "files": {
-    "extracted": [],
-    "supplementary": [
+    "extracted": [
       {
         "name": "com/opensymphony/xwork2/util/StrutsLocalizedTextProvider.java",
         "sha256": "02525ad24d34a0ac6ce6a4927fe701184be192e99b1b5e4ab83d8a7119f4511a"
@@ -684,7 +683,8 @@
         "name": "com/opensymphony/xwork2/interceptor/ParametersInterceptor.java",
         "sha256": "fcee3b68fd0696b350ce2865a7e3848900b297faab7a6ca0619c5a1cf8e16a7d"
       }
-    ]
+    ],
+    "supplementary": []
   },
   "results": {
     "heuristics": [


### PR DESCRIPTION
Changes:
- refactor espresso to not use class variable per execution
- remove useless functions
- add decompiled class files to extracted
  - add as many decompiled class files to extracted as possible. The rest goes to supplementary file
  - results.jsons are changed to reflect this. 